### PR TITLE
Add support for specifying a commit message prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following provider block variables are available for configuration:
 
 | Name | Description |
 | ---- | ----------- |
+| `commit_message_prefix` | An optional prefix to be added to all commits generated as a result of manipulating files. |
 | `github_email` | The email address to use for commit messages.<br>If a GPG key is provided, this must match the one which the key corresponds to. |
 | `github_token` | A GitHub authorisation token with `repo` permissions and having `admin` access to the target repositories. |
 | `github_username` | The username to use for commit messages. |

--- a/githubfile/provider.go
+++ b/githubfile/provider.go
@@ -30,19 +30,21 @@ const (
 )
 
 const (
-	githubEmailKey    = "github_email"
-	githubTokenKey    = "github_token"
-	githubUsernameKey = "github_username"
-	gpgPassphraseKey  = "gpg_passphrase"
-	gpgSecretKeyKey   = "gpg_secret_key"
+	commitMessagePrefixKey = "commit_message_prefix"
+	githubEmailKey         = "github_email"
+	githubTokenKey         = "github_token"
+	githubUsernameKey      = "github_username"
+	gpgPassphraseKey       = "gpg_passphrase"
+	gpgSecretKeyKey        = "gpg_secret_key"
 )
 
 type providerConfiguration struct {
-	githubClient   *github.Client
-	githubEmail    string
-	githubUsername string
-	gpgPassphrase  string
-	gpgSecretKey   string
+	commitMessagePrefix string
+	githubClient        *github.Client
+	githubEmail         string
+	githubUsername      string
+	gpgPassphrase       string
+	gpgSecretKey        string
 }
 
 func Provider() *schema.Provider {
@@ -60,17 +62,25 @@ func Provider() *schema.Provider {
 				sk = string(v)
 			}
 			return &providerConfiguration{
-				githubClient:   github.NewClient(tc),
-				githubEmail:    d.Get(githubEmailKey).(string),
-				githubUsername: d.Get(githubUsernameKey).(string),
-				gpgSecretKey:   sk,
-				gpgPassphrase:  d.Get(gpgPassphraseKey).(string),
+				commitMessagePrefix: d.Get(commitMessagePrefixKey).(string),
+				githubClient:        github.NewClient(tc),
+				githubEmail:         d.Get(githubEmailKey).(string),
+				githubUsername:      d.Get(githubUsernameKey).(string),
+				gpgSecretKey:        sk,
+				gpgPassphrase:       d.Get(gpgPassphraseKey).(string),
 			}, nil
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			resourceFileName: resourceFile(),
 		},
 		Schema: map[string]*schema.Schema{
+			commitMessagePrefixKey: {
+				Type:        schema.TypeString,
+				DefaultFunc: defaultFuncForKey(commitMessagePrefixKey),
+				Optional:    true,
+				Sensitive:   false,
+				Description: "An optional prefix to be added to all commits created as a result of manipulating files.",
+			},
 			githubEmailKey: {
 				Type:        schema.TypeString,
 				DefaultFunc: defaultFuncForKey(githubEmailKey),

--- a/githubfile/resource_file.go
+++ b/githubfile/resource_file.go
@@ -17,6 +17,7 @@ package githubfile
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/form3tech-oss/go-github-utils/pkg/branch"
@@ -98,7 +99,7 @@ func resourceFileCreateOrUpdate(s string, d *schema.ResourceData, m interface{})
 	if err := commit.CreateCommit(context.Background(), c.githubClient, &commit.CommitOptions{
 		RepoOwner:                   f.repositoryOwner,
 		RepoName:                    f.repositoryName,
-		CommitMessage:               fmt.Sprintf(s, f.path),
+		CommitMessage:               formatCommitMessage(c.commitMessagePrefix, s, f.path),
 		GpgPassphrase:               c.gpgPassphrase,
 		GpgPrivateKey:               c.gpgSecretKey,
 		Username:                    c.githubUsername,
@@ -150,7 +151,7 @@ func resourceFileDelete(d *schema.ResourceData, m interface{}) error {
 	if err := commit.CreateCommit(context.Background(), c.githubClient, &commit.CommitOptions{
 		RepoOwner:                   f.repositoryOwner,
 		RepoName:                    f.repositoryName,
-		CommitMessage:               fmt.Sprintf("Delete %q.", f.path),
+		CommitMessage:               formatCommitMessage(c.commitMessagePrefix, "Delete %q.", f.path),
 		GpgPassphrase:               c.gpgPassphrase,
 		GpgPrivateKey:               c.gpgSecretKey,
 		Username:                    c.githubUsername,
@@ -193,4 +194,11 @@ func resourceFileRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceFileUpdate(d *schema.ResourceData, m interface{}) error {
 	return resourceFileCreateOrUpdate("Update %q.", d, m)
+}
+
+func formatCommitMessage(p, m string, args ...interface{}) string {
+	if p == "" {
+		return fmt.Sprintf(m, args...)
+	}
+	return fmt.Sprintf(strings.TrimSpace(p)+" "+m, args...)
 }


### PR DESCRIPTION
This PR adds support for specifying a commit message prefix to be used in all commits made by the provider. This can be used, for example, to force CI to be skipped.