### PR TITLE
Fixes incosistent destroy if default branch change

### DIFF
--- a/githubfile/resource_file.go
+++ b/githubfile/resource_file.go
@@ -159,6 +159,7 @@ func resourceFileDelete(d *schema.ResourceData, m interface{}) error {
 		Changes:                     newTree,
 		BaseTreeOverride:            github.String(""),
 		PullRequestSourceBranchName: fmt.Sprintf("terraform-provider-githubfile-%d", time.Now().UnixNano()),
+		Branch:                      f.branch,
 		PullRequestBody:             "",
 		MaxRetries:                  3,
 		RetryBackoff:                5 * time.Second,

--- a/githubfile/resource_file_test.go
+++ b/githubfile/resource_file_test.go
@@ -43,6 +43,15 @@ resource "githubfile_file" "foo" {
 	contents         = "foo\nbar\nqux"
 }
 `
+	testAccFileUpdatueNewBranch = `
+resource "githubfile_file" "foo" {
+    repository_owner = "form3tech-oss"
+    repository_name  = "terraform-provider-githubfile-test"
+	branch           = "main"
+	path             = "foo/bar/baz/README.md"
+	contents         = "foo\nbar\nqux"
+}
+`
 )
 
 func TestAccResourceFile_basic(t *testing.T) {
@@ -83,6 +92,16 @@ func TestAccResourceFile_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, repositoryNameAttributeName, "terraform-provider-githubfile-test"),
 					resource.TestCheckResourceAttr(resourceName, repositoryOwnerAttributeName, "form3tech-oss"),
 					resource.TestCheckResourceAttr(resourceName, branchAttributeName, "master"),
+					resource.TestCheckResourceAttr(resourceName, pathAttributeName, "foo/bar/baz/README.md"),
+					resource.TestCheckResourceAttr(resourceName, contentsAttributeName, "foo\nbar\nqux"),
+				),
+			},
+			{
+				Config: testAccFileUpdatueNewBranch,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, repositoryNameAttributeName, "terraform-provider-githubfile-test"),
+					resource.TestCheckResourceAttr(resourceName, repositoryOwnerAttributeName, "form3tech-oss"),
+					resource.TestCheckResourceAttr(resourceName, branchAttributeName, "main"),
 					resource.TestCheckResourceAttr(resourceName, pathAttributeName, "foo/bar/baz/README.md"),
 					resource.TestCheckResourceAttr(resourceName, contentsAttributeName, "foo\nbar\nqux"),
 				),

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/form3tech-oss/terraform-provider-githubfile
 
-go 1.12
-
-replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+go 1.15
 
 require (
 	cloud.google.com/go v0.44.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
+git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Azure/azure-sdk-for-go v21.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v10.15.4+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=


### PR DESCRIPTION
Fixes #14

Delete should remove the file from the specified branch for the
resource. Currently it makes a delete into the repo's default branch not
the specifed branch. This makes the target branch of the delete the
resource branch
Signed-off-by: Alistair Hey <alistair.hey@form3.tech>