### PR TITLE
fix: On update failure clear Id

### DIFF
--- a/githubfile/resource_file.go
+++ b/githubfile/resource_file.go
@@ -197,7 +197,11 @@ func resourceFileRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceFileUpdate(d *schema.ResourceData, m interface{}) error {
-	return resourceFileCreateOrUpdate("Update %q.", d, m)
+	if err := resourceFileCreateOrUpdate("Update %q.", d, m); err != nil {
+		d.SetId("")
+		return err
+	}
+	return nil
 }
 
 func formatCommitMessage(p, m string, args ...interface{}) string {


### PR DESCRIPTION
The hashicorp blog entry https://www.hashicorp.com/blog/writing-custom-terraform-providers, mentions that if the update function returns an error the state is updated nonetheless, to have proper error handling the id should be cleared:

> If the Update callback returns with or without an error, the full state is saved. If the ID becomes blank, the resource is destroyed (even within an update, though this shouldn't happen except in error scenarios).

We noticed that is some runs where we exceed the amount of requests allowed by github we got the error:
> Error: failed to create commit: POST https://api.github.com/repos/.../.../pulls: 403 You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.

But when we retry later terraform didn't do ant updates because the sate had been updated, to avoid this we changed the code to clear the Id when error is returned.