### PR TITLE
chore: add on tags to enable publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*.*.*
   pull_request:
 
 jobs:


### PR DESCRIPTION
Motivation:
- The publish logic is never triggered because the tags event is never caught.