### PR TITLE
fix: Add missing GITHUB_TOKEN for goreleaser

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,3 +32,5 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       - name: Goreleaser
         run: ./scripts/goreleaser.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Motivation
- Releaser requires the existence of github token as an environment variable